### PR TITLE
Use SELECT VERSION() for initial test

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,7 +8,7 @@ const connection = mysql.createConnection(process.env.DATABASE_URL)
 connection.connect()
 
 app.get('/', (req, res) => {
-  connection.query('SELECT * from users', function (err, rows, fields) {
+  connection.query('SELECT VERSION()', function (err, rows, fields) {
     if (err) throw err
 
     res.send(rows)


### PR DESCRIPTION
While following the tutorial from these docs...
https://docs.planetscale.com/tutorial/connect-nodejs-app

...I created a database without the demo dataset.
The initial request error'ed.

Maybe the experience could be slightly nicer
by using `SELECT VERSION()` to guarantee a satisfying 200?

```
[{"VERSION()":"8.0.23"}]
```