### PR TITLE
Fix option to connect with client certs

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,6 +16,8 @@ let connection = {};
   OPTION 2:
     Use if you're connecting with client certificates via CLI (see docs)
     https://docs.planetscale.com/tutorials/connect-nodejs-app#using-client-certificates-with-the-cli
+    
+  Feel free to remove the if/else statement once you decide which you'll use
 */
 
 if (process.env.DATABASE_HOST) {

--- a/app.js
+++ b/app.js
@@ -4,15 +4,33 @@ const app = express()
 const port = process.env.PORT || 3000
 
 const mysql = require('mysql2')
-const connection = mysql.createConnection({
-  host : process.env.DATABASE_HOST,
-  database: process.env.DATABASE_NAME,
-  user : process.env.DATABASE_USERNAME,
-  password : process.env.DATABASE_PASSWORD,
-  ssl : {
-      rejectUnauthorized: true
-  }
-});
+let connection = {};
+
+/*
+  ---- Note: You only need one connection object in the if/else statement ----
+
+  OPTION 1:
+    Use if you're using connection strings in your app (see docs)
+    https://docs.planetscale.com/tutorials/connect-nodejs-app#using-a-connection-string
+
+  OPTION 2:
+    Use if you're connecting with client certificates via CLI (see docs)
+    https://docs.planetscale.com/tutorials/connect-nodejs-app#using-client-certificates-with-the-cli
+*/
+
+if (process.env.DATABASE_HOST) {
+  connection = mysql.createConnection({
+    host : process.env.DATABASE_HOST,
+    database: process.env.DATABASE_NAME,
+    user : process.env.DATABASE_USERNAME,
+    password : process.env.DATABASE_PASSWORD,
+    ssl : {
+        rejectUnauthorized: true
+    }
+  });
+} else {
+  connection = mysql.createConnection(process.env.DATABASE_URL)
+}
 
 connection.connect()
 


### PR DESCRIPTION
Just noticed the option to [connect with client certificates via CLI](https://docs.planetscale.com/tutorials/connect-nodejs-app#using-client-certificates-with-the-cli) doesn't work anymore after the last update(s?).

I added 2 options for the connection object so that it will work smoothly either way if people run straight from the docs w/o looking at the repo and fiddling with anything. Lmk if there's a better way!