### PR TITLE
docs(readme): clarify Vitess/MySQL vs Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Express.js + PlanetScale example
 
-> **Note:** This example targets PlanetScale Vitess/MySQL. PlanetScale also offers managed PostgreSQL. For more information, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
+> **Note:** This example targets PlanetScale Vitess/MySQL. PlanetScale also offers managed Postgres. For more information, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
 
 Example Express.js/Node app using PlanetScale.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Express.js + PlanetScale example
 
-> **Note:** This example uses the PlanetScale CLI MySQL shell and `mysql://` connection strings for PlanetScale Vitess/MySQL. PlanetScale also offers managed PostgreSQL. For more information and examples, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
+> **Note:** This example targets PlanetScale Vitess/MySQL. PlanetScale also offers managed PostgreSQL. For more information, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
 
 Example Express.js/Node app using PlanetScale.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Express.js + PlanetScale example
 
+> **Note:** This example uses the PlanetScale CLI MySQL shell and `mysql://` connection strings for PlanetScale Vitess/MySQL. PlanetScale also offers managed PostgreSQL. For more information and examples, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
+
 Example Express.js/Node app using PlanetScale.
 
 ## Prerequisites


### PR DESCRIPTION
## Summary

- README: clarify that this repository targets PlanetScale Vitess/MySQL (or the MySQL tooling shown in the repo), not PlanetScale-only-MySQL.
- Link readers to Postgres documentation at https://planetscale.com/docs/postgres for managed PostgreSQL databases.

PlanetScale offers both MySQL-compatible (Vitess) and PostgreSQL products.

Made with [Cursor](https://cursor.com)